### PR TITLE
Add parse_guess function that parses dates by guessing many common formats

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -197,7 +197,7 @@ class DateTimeParser(object):
 
     # Patterns for guessing dates. These are used without escaping. They combine multiple
     # patterns. An important restriction is that each name must only appear once in a pattern.
-    _TIME_PATTERN = 'H(::m(::s(.S)?)?(A)?|a)( )?(Z|ZZZ)?'
+    _TIME_PATTERN = 'H(::m(::s(.S)?)?(--A)?|--a)(--Z| ZZZ)?'
     _MAYBE_TIME_PATTERN = '(( |T){})?'.format(_TIME_PATTERN)
     _GUESS_PATTERNS = [
         'YYYY//M(//D)?{}'.format(_MAYBE_TIME_PATTERN),
@@ -218,6 +218,7 @@ class DateTimeParser(object):
                 fmt_tokens, fmt_pattern_re = self._generate_pattern_unescaped(pattern)
                 fmt_pattern_re = r'^\s*{}\s*$'.format(fmt_pattern_re
                                                       .replace(' ', r'\W+')
+                                                      .replace('--', r'\W*?')
                                                       .replace('//', r'\s*[-/\s]\s*')
                                                       .replace('::', r'\s*[-:\s]\s*'))
                 self._guess_patterns.append(

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -878,6 +878,12 @@ class DateTimeParserGuessTests(Chai):
                     datetime(1993,4,2,22,18,4,tzinfo=tz_la))
         assertEqual(self.parser.parse_guess('April 2nd, 1993 22:18:04 Japan'),
                     datetime(1993,4,2,22,18,4,tzinfo=tz_jp))
+        assertEqual(self.parser.parse_guess('2018-02-27 16:08:39 -0100'),
+                    datetime(2018,2,27,16,8,39,tzinfo=tz.tzoffset(None, -3600)))
+        assertEqual(self.parser.parse_guess('2018-02-27 16:08:39 +0000'),
+                    datetime(2018,2,27,16,8,39,tzinfo=utc))
+        assertEqual(self.parser.parse_guess('2018-02-27 16:08:39 +0100'),
+                    datetime(2018,2,27,16,8,39,tzinfo=tz.tzoffset(None, +3600)))
 
     def test_parse_iso_dates(self):
         assertEqual(self.parser.parse_guess('2013-02-03T04:05:06.7891+01:00'),
@@ -906,9 +912,12 @@ class DateTimeParserGuessTests(Chai):
         assertEqual(self.parser.parse_guess('5:25pm'), datetime(2018, 4, 17, 17, 25))
         assertEqual(self.parser.parse_guess('17:25'), datetime(2018, 4, 17, 17, 25))
         assertEqual(self.parser.parse_guess('17:25PM'), datetime(2018, 4, 17, 17, 25))
+        assertEqual(self.parser.parse_guess('17:25 Pm'), datetime(2018, 4, 17, 17, 25))
         assertEqual(self.parser.parse_guess('5PM'), datetime(2018, 4, 17, 17, 0))
+        assertEqual(self.parser.parse_guess('5 PM'), datetime(2018, 4, 17, 17, 0))
         assertEqual(self.parser.parse_guess('5am'), datetime(2018, 4, 17, 5, 0))
         assertEqual(self.parser.parse_guess('12am'), datetime(2018, 4, 17, 0, 0))
+        assertEqual(self.parser.parse_guess('12/am'), datetime(2018, 4, 17, 0, 0))
         assertEqual(self.parser.parse_guess('0:0'), datetime(2018, 4, 17, 0, 0))
 
     def test_failure(self):


### PR DESCRIPTION
After a few attempts, I decided that the easiest way would be to tweak arrow itself. In this branch (`parse_guess` branch) I added a `parse_guess()` method (see unittests for how to actually call it). It will parse a date in many formats.

It does NOT actually tell you what format it used, and doing that wouldn't be so easy. So basically it just replicates what `dateutil.parser.parse()` does.

Julia, if you could try it, and check its performance (is it faster than dateutil or slower?) and whether it handles various formats (in case I forgot something in the test), then we can decide if it's worth pursuing further.